### PR TITLE
Typed JS first try on banner

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -53,6 +53,5 @@
 .fa-space-shuttle {
   color: white;
   position: relative;
-  top: -7px;
-
+  top: -7px
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -52,6 +52,4 @@
 
 .fa-space-shuttle {
   color: white;
-  position: relative;
-  top: -7px
 }

--- a/app/javascript/components/banner_typed.js
+++ b/app/javascript/components/banner_typed.js
@@ -7,7 +7,7 @@ const loadDynamicBannerText = () => {
     loop: true,
     fadeOut: true,
     fadeOutDelay: 1,
-    cursorChar: "<span class='fas fa-space-shuttle'></span>"
+    showCursor: false
   });
 }
 

--- a/app/javascript/components/banner_typed.js
+++ b/app/javascript/components/banner_typed.js
@@ -1,0 +1,14 @@
+import Typed from 'typed.js';
+
+const loadDynamicBannerText = () => {
+  new Typed('#banner-typed-text', {
+    strings: ["The best spaceship rent service of the universe!"],
+    typeSpeed: 50,
+    loop: true,
+    fadeOut: true,
+    fadeOutDelay: 1,
+    cursorChar: "<span class='fas fa-space-shuttle'></span>"
+  });
+}
+
+export { loadDynamicBannerText };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,6 +31,7 @@ import "bootstrap";
 import { navbarScroll } from '../components/navbar_scroll';
 import { displayShipDetails } from '../components/ss_show_details';
 import { flatpickrCalendar } from "../plugins/flatpickr"
+import { loadDynamicBannerText } from '../components/banner_typed';
 import { updateBookingAmount } from '../components/update_booking_amount.js'
 
 document.addEventListener('turbolinks:load', () => {
@@ -39,5 +40,6 @@ document.addEventListener('turbolinks:load', () => {
   navbarScroll();
   displayShipDetails();
   flatpickrCalendar();
+  loadDynamicBannerText();
   updateBookingAmount();
 });

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,12 +3,12 @@
     <div class="banner-content">
       <h1 class="home-title text-center">STARSHIPS<br>LOOTERS</h1>
       <div class="sub d-flex justify-content-center align-items-center">
-        <p class="subtitle text-center">The best spaceship rent service of the universe! </p>
-        <i class="fas fa-space-shuttle ml-1"></i>
+        <p class="subtitle text-center">
+          <i class="fas fa-space-shuttle fa-flip-horizontal"></i>
+          <span id="banner-typed-text"></span>
+          <i class='fas fa-space-shuttle'></i>
+        </p>
       </div>
-      <p class="subtitle text-center">
-        <span id="banner-typed-text"></span>
-      </p>
       <br>
       <div class="text-center"><h1><%= link_to "Start your ride now!", ships_path(), class: "btn btn-success btn-shadow" %></h1></div>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,7 +6,10 @@
         <p class="subtitle text-center">The best spaceship rent service of the universe! </p>
         <i class="fas fa-space-shuttle ml-1"></i>
       </div>
-        <br>
+      <p class="subtitle text-center">
+        <span id="banner-typed-text"></span>
+      </p>
+      <br>
       <div class="text-center"><h1><%= link_to "Start your ride now!", ships_path(), class: "btn btn-success btn-shadow" %></h1></div>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "flatpickr": "^4.6.6",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "typed.js": "^2.0.11"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,6 +7167,11 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed.js@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/typed.js/-/typed.js-2.0.11.tgz#d298a91f959f11a3803bf48b841a6fadd29640d9"
+  integrity sha512-1ZORHalEyLob34q738mqmwp0pT6syMigB1SZuTItqdhovWBKFIt7I5uVALXAGQZCg2MCtihCt6uqkoqPJK+9iQ==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"


### PR DESCRIPTION
Typed JS works fine with Fontawesome.
On this version, the shuttle is not aligned with the text due to CSS rules for the static subtitle.
When I remove these settings, typed text and icon are aligned well.
![image](https://user-images.githubusercontent.com/70663477/100394131-4b093e00-303c-11eb-8043-8074435d76a8.png)

Just a doubt about the position of the component.
Centered like the original one, the render is strange.
It's possible to align the component on the left with a left padding 312 to align the 2 subtitles, but when the window is reduced, the result is not.
To be discuted tomorrow morning.

If you want to test it, you have to run a **yarn install** to locally include typed.js (or maybe you have to execute a **yarn add typed.js**, I'm not sure).