### PR TITLE
Set background color for the toggler navbar menu

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -35,3 +35,7 @@
   padding: 3px 10px;
   border-radius: 25px;
 }
+
+.navbar-toggler {
+  background-color: white;
+}


### PR DESCRIPTION
Just add white background color to the toggler navbar menu (visible on small screen).